### PR TITLE
Also quit history previous mode with C-g

### DIFF
--- a/history.el
+++ b/history.el
@@ -202,6 +202,7 @@ See `advice' feature."
     (define-key map (kbd "<return>") 'exit-minibuffer)
     (define-key map (kbd "q") 'history-preview-cancel-history)
     (define-key map (kbd "<escape>") 'history-preview-cancel-history)
+    (define-key map (kbd "C-g") 'history-preview-cancel-history)
     map)
   "The key map for browsing the history.")
 


### PR DESCRIPTION
My fingers have been trained over many years that to get rid of the
whatever is active in the minibuffer I should press the standard Emacs
C-g. Since C-g otherwise unhelpfully says "Quit" in the minibuffer but
otherwise does nothing, it might as well call
history-preview-cancel-history so that it acts the same as pressing q or
ESC.