### PR TITLE
Use RET rather than <return> for terminal compatibility

### DIFF
--- a/history.el
+++ b/history.el
@@ -199,7 +199,7 @@ See `advice' feature."
     (define-key map (kbd "<right>") 'history-preview-next-history)
     (define-key map (kbd "C-p") 'history-preview-prev-history)
     (define-key map (kbd "C-n") 'history-preview-next-history)
-    (define-key map (kbd "<return>") 'exit-minibuffer)
+    (define-key map (kbd "RET") 'exit-minibuffer)
     (define-key map (kbd "q") 'history-preview-cancel-history)
     (define-key map (kbd "<escape>") 'history-preview-cancel-history)
     map)


### PR DESCRIPTION
When using Emacs 26.3 and Emacs 26.1 in a terminal, pressing the Enter
key when navigating the history just causes a newline to appear in the
minibuffer splitting the history display.

It appears that "<return>" is only generated by graphical Emacs. All the
other packages I looked at bound "RET" instead, which also works in
graphical Emacs so it appears to be better to use that instead.